### PR TITLE
Fix documentation generation

### DIFF
--- a/doc/Jamfile
+++ b/doc/Jamfile
@@ -257,7 +257,7 @@ install images
 
 explicit images ;
 
-xml beast_doc
+xml library_template_doc
     :
         qbk/main.qbk
     :
@@ -275,7 +275,7 @@ explicit beast_doc ;
 
 boostbook library_template
     :
-        beast_doc
+        library_template_doc
     :
         <xsl:param>boost.root=../../../..
         <xsl:param>chapter.autolabel=1

--- a/doc/qbk/quickref.xml
+++ b/doc/qbk/quickref.xml
@@ -7,7 +7,7 @@
   Distributed under the Boost Software License, Version 1.0. (See accompanying
   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-  Official repository: https://github.com/vinniefalco/json
+  Official repository: https://github.com/vinniefalco/library_template
 -->
 
 <informaltable frame="all">

--- a/doc/xsl/config.xsl
+++ b/doc/xsl/config.xsl
@@ -2,5 +2,5 @@
 <xsl:variable name="doc-ref" select="'library_template.ref'"/>
 <xsl:variable name="doc-ns" select="'boost::library_template'"/>
 <xsl:variable name="debug" select="0"/>
-<xsl:variable name="private" select="0"/>
+<xsl:variable name="include-private-members" select="false()"/>
 <!-- End Variables -->


### PR DESCRIPTION
Just some minor things that added a bit of confusion when trying to use this as a base for generating documentation for my (non-official) boost library.